### PR TITLE
Wake-T example update

### DIFF
--- a/docs/example_simulations/single_stage/wake_t_cylindrical.py
+++ b/docs/example_simulations/single_stage/wake_t_cylindrical.py
@@ -28,7 +28,7 @@ def density_profile(z, r):
     z0 = l_ramp + l_plateau
     n = np.where((z >= z0) & (z <= z0 + l_ramp), 
                  (1 - 0.5 * (1 - np.cos(np.pi * (z - z0) / l_ramp))) * n, n)
-    # Set to a very small, non-zero value outside the plasma border
+    # Set to a very small, non-zero value outside the plasma borders to avoid divide by zero
     n = np.where(z <= 0.0, 1e-10 * n_p0, n)
     n = np.where(z >= z0 + l_ramp, 1e-10 * n_p0, n)
     n = np.where(n == 0, 1e-10 * n_p0, n)  # fix having zero in the last point
@@ -160,14 +160,14 @@ nr = int(r_max / dr)
 dz_fields = 200e-6  # wakefield calculation period
 
 # Adaptive grid setup
-res_beam_r = 5.  # Beam radial resolution: number of grid points per sigma
+res_beam_r = 10.  # Beam radial resolution: number of grid points per sigma
 adaptive_dr = np.min([sx0, sy0]) / res_beam_r
 sxi = np.std(x)  # initial beam rms size in x
 syi = np.std(y)  # initial beam rms size in y
 adaptive_grid_r_max = 4 * np.max([sxi, syi])
 adaptive_grid_nr = int(adaptive_grid_r_max / adaptive_dr)
 # add more particles in the adaptive grid region to match the increased resolution
-# Extends the region with more particles a bit beyond the adaptive grid border
+# Extends the region with more particles beyond the adaptive grid borders
 ppc = 2
 ppc = [[1.5 * adaptive_grid_r_max, ppc * int(dr / adaptive_dr)],
        [r_max_plasma, ppc]]


### PR DESCRIPTION
- Restructure a bit the script with differentiated sections for the laser, the plasma profile, the witness beam and the plasma stage simulation.
- Put `beamline.track` in `if __name__ == "__main__":`.
(this allows importing elements from the script in post-processing without actually running the simulation) 
- Explicitly select `a` for the diagnostics. Default is still `a_mod` and `a_phi`, which does not work with `LASY`.
- Add parabolic coefficient in the `density_profile` function definition and simplifies the profile definition.
- Remove beam energy arrays and unnecessary functions.
- Matched beam size is now calculated from theory for perfect blowout (there was a typo in the empirically obtained matched betas).
- Add ion motion and adaptive grid.
- Fix a bug in trapezoidal bunch creation routine.
- Add ramps to the plasma density profile. 
- Allow selecting the virtual focus of the beam.